### PR TITLE
Fixed proc names to match existing procs so build will succeed.

### DIFF
--- a/src/pothole/api/nodeinfo.nim
+++ b/src/pothole/api/nodeinfo.nim
@@ -49,7 +49,7 @@ proc nodeInfo2x0*(req: Request) =
     totalSessions = db.getTotalSessions()
     totalValidSessions = db.getTotalValidSessions()
     totalUsers = db.getTotalLocalUsers()
-    totalPosts = db.getTotalPosts()
+    totalPosts = db.getNumTotalPosts()
 
   configPool.withConnection config:
     var protocols: seq[string] = @[]

--- a/src/pothole/private/apientities.nim
+++ b/src/pothole/private/apientities.nim
@@ -63,7 +63,7 @@ proc account*(user_id: string): JsonNode =
     user = db.getUserById(user_id)
     followers = db.getFollowersCount(user_id)
     following = db.getFollowingCount(user_id)
-    totalPosts = db.getTotalPostsByUserId(user_id)
+    totalPosts = db.getNumPostsByUser(user_id)
 
   configPool.withConnection config:
     avatar = config.getAvatar(user_id)
@@ -183,7 +183,7 @@ proc v1Instance*(): JsonNode =
 
   dbPool.withConnection db:
     userCount = db.getTotalLocalUsers()
-    postCount = db.getTotalPosts()
+    postCount = db.getNumTotalPosts()
     domainCount = db.getTotalDomains()
     admin = db.getFirstAdmin()
 


### PR DESCRIPTION
The build failed because the following procs didn't exist, but they were being called:

`db.getTotalPostsByUserId`
`db.getTotalPosts`

I replaced them with calls to procs which do exist:

`db.getNumPostsByUser`
`db.getNumTotalPosts`

Now it successfully builds.

ISSUE: https://github.com/penguinite/pothole/issues/2